### PR TITLE
Added missing return value for copy constructor - prevent crashing

### DIFF
--- a/def/defiBlockage.cpp
+++ b/def/defiBlockage.cpp
@@ -136,6 +136,7 @@ DEF_ASSIGN_OPERATOR_C( defiBlockage ) {
   DEF_COPY_FUNC( polysAllocated_ );
   DEF_MALLOC_FUNC_FOR_2D_POINT ( polygons_, numPolys_ );
 
+  return *this;
 }
 
 defiBlockage::~defiBlockage() {

--- a/def/defiComponent.cpp
+++ b/def/defiComponent.cpp
@@ -69,6 +69,7 @@ DEF_ASSIGN_OPERATOR_C( defiComponentMaskShiftLayer ) {
     DEF_COPY_FUNC( layersAllocated_ );
     DEF_COPY_FUNC( numLayers_ );
     DEF_MALLOC_FUNC_FOR_2D_STR( layers_ , numLayers_ );
+    return *this;
 }
 
 defiComponentMaskShiftLayer::~defiComponentMaskShiftLayer() {

--- a/def/defiMisc.cpp
+++ b/def/defiMisc.cpp
@@ -64,6 +64,7 @@ DEF_ASSIGN_OPERATOR_C( defiPoints ) {
     DEF_COPY_FUNC( numPoints );
     DEF_MALLOC_FUNC( x, int, sizeof(int) * numPoints );
     DEF_MALLOC_FUNC( y, int, sizeof(int) * numPoints );
+    return *this;
 }
 
 

--- a/def/defiNet.cpp
+++ b/def/defiNet.cpp
@@ -143,6 +143,7 @@ DEF_ASSIGN_OPERATOR_C( defiWire ) {
     else {
         paths_ = 0; 
     }
+    return *this;
 }
 
 
@@ -350,6 +351,7 @@ DEF_ASSIGN_OPERATOR_C( defiSubnet ) {
     DEF_MALLOC_FUNC_FOR_2D( wires_, defiWire, numWires_, 1 );
     DEF_MALLOC_FUNC( nonDefaultRule_, char, sizeof(char) * (strlen(prev.nonDefaultRule_) +1));
 
+    return *this;
 }
 
 void defiSubnet::Destroy() {
@@ -794,6 +796,7 @@ DEF_ASSIGN_OPERATOR_C( defiVpin ) {
     DEF_MALLOC_FUNC( name_, char, sizeof(char) * (strlen(prev.name_) +1));
     DEF_MALLOC_FUNC( layer_, char, sizeof(char) * (strlen(prev.layer_) +1));
 
+    return *this;
 }
 
 void defiVpin::Destroy() {
@@ -930,6 +933,7 @@ DEF_ASSIGN_OPERATOR_C( defiShield ) {
     DEF_COPY_FUNC( numPaths_ );
     DEF_COPY_FUNC( pathsAllocated_ );
     DEF_MALLOC_FUNC_FOR_2D( paths_, defiPath, numPaths_, 1 );
+    return *this;
 }
 
 void defiShield::Destroy() {
@@ -1411,6 +1415,7 @@ DEF_ASSIGN_OPERATOR_C( defiNet ) {
     DEF_MALLOC_FUNC_FOR_2D_STR( viaRouteStatusShieldNames_, numPts_ ); 
     DEF_MALLOC_FUNC_FOR_2D_STR( viaShapeTypes_, numPts_ ); 
 
+    return *this;
 }
 
 void defiNet::Destroy() {

--- a/def/defiPath.cpp
+++ b/def/defiPath.cpp
@@ -277,6 +277,7 @@ DEF_ASSIGN_OPERATOR_C( defiPath ) {
     DEF_COPY_FUNC( deltaY_ );
     DEF_COPY_FUNC( mask_ );
 
+    return *this;
 }
 
 defiPath::~defiPath() {

--- a/def/defiPinCap.cpp
+++ b/def/defiPinCap.cpp
@@ -156,6 +156,7 @@ DEF_ASSIGN_OPERATOR_C( defiPinAntennaModel ) {
     DEF_COPY_FUNC( APinMaxCutCarAllocated_ );
     DEF_MALLOC_FUNC( APinMaxCutCar_, int, sizeof(int) * numAPinMaxCutCar_ );
     DEF_MALLOC_FUNC_FOR_2D_STR( APinMaxCutCarLayer_, numAPinMaxCutCar_ );
+    return *this;
 }
 
 defiPinAntennaModel::~defiPinAntennaModel() {
@@ -579,6 +580,7 @@ DEF_ASSIGN_OPERATOR_C( defiPinPort ) {
     DEF_COPY_FUNC( x_ );
     DEF_COPY_FUNC( y_ );
     DEF_COPY_FUNC( orient_ );
+    return *this;
 }
 
 defiPinPort::~defiPinPort() {
@@ -1247,6 +1249,7 @@ DEF_ASSIGN_OPERATOR_C( defiPin ) {
     DEF_COPY_FUNC( hasGroundSens_ );
     DEF_MALLOC_FUNC( groundSens_, char, sizeof(char) * (strlen(prev.groundSens_) +1));
 
+    return *this;
 }
 
 defiPin::~defiPin() {

--- a/def/defiProp.cpp
+++ b/def/defiProp.cpp
@@ -79,6 +79,7 @@ DEF_ASSIGN_OPERATOR_C( defiProp ) {
     DEF_COPY_FUNC( left_ );
     DEF_COPY_FUNC( right_ );
     DEF_COPY_FUNC( d_ );
+    return *this;
 }
 
 

--- a/def/defiRowTrack.cpp
+++ b/def/defiRowTrack.cpp
@@ -122,6 +122,7 @@ DEF_ASSIGN_OPERATOR_C( defiRow ) {
     DEF_MALLOC_FUNC( propDValues_, double, sizeof(double) * numProps_);
     DEF_MALLOC_FUNC( propTypes_, char, sizeof(char) * numProps_ );
 
+    return *this;
 }
 
 defiRow::~defiRow() {
@@ -484,6 +485,7 @@ DEF_ASSIGN_OPERATOR_C( defiTrack ) {
     DEF_COPY_FUNC( firstTrackMask_ );
     DEF_COPY_FUNC( samemask_ );
 
+    return *this;
 }
 
 defiTrack::~defiTrack() {
@@ -663,6 +665,7 @@ DEF_ASSIGN_OPERATOR_C( defiGcellGrid ) {
     DEF_COPY_FUNC( x_ );
     DEF_COPY_FUNC( xNum_ );
     DEF_COPY_FUNC( xStep_ );
+    return *this;
 }
 
 defiGcellGrid::~defiGcellGrid() {

--- a/def/defiSite.cpp
+++ b/def/defiSite.cpp
@@ -217,6 +217,7 @@ DEF_ASSIGN_OPERATOR_C( defiBox ) {
     DEF_COPY_FUNC( yh_ );
     
     DEF_MALLOC_FUNC_WITH_OPERATOR( points_, defiPoints, sizeof(defiPoints)*1 );
+    return *this;
 }
 
 defiBox::~defiBox() {

--- a/def/defiVia.cpp
+++ b/def/defiVia.cpp
@@ -168,6 +168,7 @@ DEF_ASSIGN_OPERATOR_C( defiVia ) {
     DEF_MALLOC_FUNC( rectMask_, int, sizeof(int) * numLayers_);
     DEF_MALLOC_FUNC( polyMask_, int, sizeof(int) * numLayers_);
 
+    return *this;
 }
 
 


### PR DESCRIPTION
Missing return value in copy constructor does not behave well in gcc 9.1.0