### PR TITLE
Remove optimization flags from lef/def parsers

### DIFF
--- a/def/defiBlockage.cpp
+++ b/def/defiBlockage.cpp
@@ -103,6 +103,7 @@ DEF_COPY_CONSTRUCTOR_C( defiBlockage ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiBlockage ) {
+  CHECK_SELF_ASSIGN
   this->Init();
   DEF_COPY_FUNC( hasLayer_ );
   DEF_MALLOC_FUNC( layerName_, char, sizeof(char) * 
@@ -135,7 +136,7 @@ DEF_ASSIGN_OPERATOR_C( defiBlockage ) {
   DEF_COPY_FUNC( numPolys_ );
   DEF_COPY_FUNC( polysAllocated_ );
   DEF_MALLOC_FUNC_FOR_2D_POINT ( polygons_, numPolys_ );
-
+  return *this;
 }
 
 defiBlockage::~defiBlockage() {

--- a/def/defiComponent.cpp
+++ b/def/defiComponent.cpp
@@ -63,12 +63,14 @@ DEF_COPY_CONSTRUCTOR_C( defiComponentMaskShiftLayer ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiComponentMaskShiftLayer ) {
+    CHECK_SELF_ASSIGN
     layersAllocated_ = 0;
     numLayers_ = 0;
     layers_ = 0;
     DEF_COPY_FUNC( layersAllocated_ );
     DEF_COPY_FUNC( numLayers_ );
     DEF_MALLOC_FUNC_FOR_2D_STR( layers_ , numLayers_ );
+    return *this;
 }
 
 defiComponentMaskShiftLayer::~defiComponentMaskShiftLayer() {

--- a/def/defiKRDefs.hpp
+++ b/def/defiKRDefs.hpp
@@ -49,6 +49,12 @@
 
 #define DEF_ASSIGN_OPERATOR_H(cname) cname& operator=(const cname & prev)
 #define DEF_ASSIGN_OPERATOR_C(cname) cname& cname::operator=(const cname & prev)
+#define CHECK_SELF_ASSIGN                                               \
+{                                                                       \
+    if (this == &prev) {                                                \
+        return *this;                                                   \
+    }                                                                   \
+}
 
 #define DEF_COPY_FUNC(varname) {(varname) = prev.varname;}
 #define DEF_MALLOC_FUNC(varname, vartype, length)                       \

--- a/def/defiMisc.cpp
+++ b/def/defiMisc.cpp
@@ -61,9 +61,11 @@ DEF_COPY_CONSTRUCTOR_C( defiPoints )
 }
 
 DEF_ASSIGN_OPERATOR_C( defiPoints ) {
+    CHECK_SELF_ASSIGN
     DEF_COPY_FUNC( numPoints );
     DEF_MALLOC_FUNC( x, int, sizeof(int) * numPoints );
     DEF_MALLOC_FUNC( y, int, sizeof(int) * numPoints );
+    return *this;
 }
 
 

--- a/def/defiNet.cpp
+++ b/def/defiNet.cpp
@@ -114,6 +114,7 @@ DEF_COPY_CONSTRUCTOR_C( defiWire ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiWire ) {
+    CHECK_SELF_ASSIGN
     type_ = 0;
     wireShieldName_ = 0;
 
@@ -143,6 +144,8 @@ DEF_ASSIGN_OPERATOR_C( defiWire ) {
     else {
         paths_ = 0; 
     }
+
+    return *this;
 }
 
 
@@ -325,6 +328,7 @@ DEF_COPY_CONSTRUCTOR_C( defiSubnet ) {
 
 
 DEF_ASSIGN_OPERATOR_C( defiSubnet ) {
+    CHECK_SELF_ASSIGN
     defData = NULL;
     this->Init();
 
@@ -349,7 +353,7 @@ DEF_ASSIGN_OPERATOR_C( defiSubnet ) {
     DEF_COPY_FUNC( wiresAllocated_ );
     DEF_MALLOC_FUNC_FOR_2D( wires_, defiWire, numWires_, 1 );
     DEF_MALLOC_FUNC( nonDefaultRule_, char, sizeof(char) * (strlen(prev.nonDefaultRule_) +1));
-
+    return *this;
 }
 
 void defiSubnet::Destroy() {
@@ -781,6 +785,7 @@ DEF_COPY_CONSTRUCTOR_C( defiVpin ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiVpin ) {
+    CHECK_SELF_ASSIGN
     defData = NULL;
 
     DEF_COPY_FUNC( xl_ );
@@ -793,7 +798,7 @@ DEF_ASSIGN_OPERATOR_C( defiVpin ) {
     DEF_COPY_FUNC( yLoc_ );
     DEF_MALLOC_FUNC( name_, char, sizeof(char) * (strlen(prev.name_) +1));
     DEF_MALLOC_FUNC( layer_, char, sizeof(char) * (strlen(prev.layer_) +1));
-
+    return *this;
 }
 
 void defiVpin::Destroy() {
@@ -924,12 +929,14 @@ DEF_COPY_CONSTRUCTOR_C( defiShield ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiShield ) {
+    CHECK_SELF_ASSIGN
     defData = NULL;
 
     DEF_MALLOC_FUNC( name_, char, sizeof(char) * (strlen(prev.name_) +1));
     DEF_COPY_FUNC( numPaths_ );
     DEF_COPY_FUNC( pathsAllocated_ );
     DEF_MALLOC_FUNC_FOR_2D( paths_, defiPath, numPaths_, 1 );
+    return *this;
 }
 
 void defiShield::Destroy() {
@@ -1279,7 +1286,7 @@ DEF_COPY_CONSTRUCTOR_C( defiNet ){
 
 
 DEF_ASSIGN_OPERATOR_C( defiNet ) {
-    
+    CHECK_SELF_ASSIGN
     DEF_COPY_FUNC(defData) ;
     this->Init();
 
@@ -1410,7 +1417,7 @@ DEF_ASSIGN_OPERATOR_C( defiNet ) {
     DEF_MALLOC_FUNC_FOR_2D_STR( viaRouteStatus_, numPts_ ); 
     DEF_MALLOC_FUNC_FOR_2D_STR( viaRouteStatusShieldNames_, numPts_ ); 
     DEF_MALLOC_FUNC_FOR_2D_STR( viaShapeTypes_, numPts_ ); 
-
+    return *this;
 }
 
 void defiNet::Destroy() {

--- a/def/defiPath.cpp
+++ b/def/defiPath.cpp
@@ -170,7 +170,7 @@ mask_(0) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiPath ) {
-
+    CHECK_SELF_ASSIGN
     this->defData = prev.defData;
     this->keys_ = NULL;
     this->data_ = NULL;
@@ -276,7 +276,7 @@ DEF_ASSIGN_OPERATOR_C( defiPath ) {
     DEF_COPY_FUNC( deltaX_ );
     DEF_COPY_FUNC( deltaY_ );
     DEF_COPY_FUNC( mask_ );
-
+    return *this;
 }
 
 defiPath::~defiPath() {

--- a/def/defiPinCap.cpp
+++ b/def/defiPinCap.cpp
@@ -134,6 +134,7 @@ DEF_COPY_CONSTRUCTOR_C( defiPinAntennaModel ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiPinAntennaModel ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     
     DEF_MALLOC_FUNC( oxide_, char, sizeof(char) * (strlen(prev.oxide_) +1));
@@ -156,6 +157,7 @@ DEF_ASSIGN_OPERATOR_C( defiPinAntennaModel ) {
     DEF_COPY_FUNC( APinMaxCutCarAllocated_ );
     DEF_MALLOC_FUNC( APinMaxCutCar_, int, sizeof(int) * numAPinMaxCutCar_ );
     DEF_MALLOC_FUNC_FOR_2D_STR( APinMaxCutCarLayer_, numAPinMaxCutCar_ );
+    return *this;
 }
 
 defiPinAntennaModel::~defiPinAntennaModel() {
@@ -545,6 +547,7 @@ DEF_COPY_CONSTRUCTOR_C( defiPinPort ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiPinPort ) {
+    CHECK_SELF_ASSIGN
     this->Init();
 
     DEF_COPY_FUNC( layersAllocated_ );
@@ -579,6 +582,7 @@ DEF_ASSIGN_OPERATOR_C( defiPinPort ) {
     DEF_COPY_FUNC( x_ );
     DEF_COPY_FUNC( y_ );
     DEF_COPY_FUNC( orient_ );
+    return *this;
 }
 
 defiPinPort::~defiPinPort() {
@@ -1162,6 +1166,7 @@ DEF_COPY_CONSTRUCTOR_C( defiPin ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiPin ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     DEF_COPY_FUNC( pinNameLength_ );
     DEF_MALLOC_FUNC( pinName_, char, sizeof(char) * (strlen(prev.pinName_) +1));
@@ -1246,7 +1251,7 @@ DEF_ASSIGN_OPERATOR_C( defiPin ) {
     DEF_COPY_FUNC( groundSensLength_ );
     DEF_COPY_FUNC( hasGroundSens_ );
     DEF_MALLOC_FUNC( groundSens_, char, sizeof(char) * (strlen(prev.groundSens_) +1));
-
+    return *this;
 }
 
 defiPin::~defiPin() {

--- a/def/defiProp.cpp
+++ b/def/defiProp.cpp
@@ -67,6 +67,7 @@ DEF_COPY_CONSTRUCTOR_C( defiProp ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiProp ) {
+    CHECK_SELF_ASSIGN
     DEF_MALLOC_FUNC( propType_, char, sizeof(char) * (strlen(prev.propType_) +1));
     DEF_MALLOC_FUNC( propName_, char, sizeof(char) * (strlen(prev.propName_) +1));
     DEF_COPY_FUNC( nameSize_ );
@@ -79,6 +80,7 @@ DEF_ASSIGN_OPERATOR_C( defiProp ) {
     DEF_COPY_FUNC( left_ );
     DEF_COPY_FUNC( right_ );
     DEF_COPY_FUNC( d_ );
+    return *this;
 }
 
 

--- a/def/defiRowTrack.cpp
+++ b/def/defiRowTrack.cpp
@@ -101,6 +101,7 @@ DEF_COPY_CONSTRUCTOR_C( defiRow ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiRow ) {
+    CHECK_SELF_ASSIGN
   this->Init();
     DEF_COPY_FUNC( nameLength_ );
     DEF_MALLOC_FUNC( name_, char, sizeof(char) * (strlen(prev.name_) +1));
@@ -121,7 +122,7 @@ DEF_ASSIGN_OPERATOR_C( defiRow ) {
     DEF_MALLOC_FUNC_FOR_2D_STR( propValues_, numProps_);
     DEF_MALLOC_FUNC( propDValues_, double, sizeof(double) * numProps_);
     DEF_MALLOC_FUNC( propTypes_, char, sizeof(char) * numProps_ );
-
+    return *this;
 }
 
 defiRow::~defiRow() {
@@ -472,6 +473,7 @@ DEF_COPY_CONSTRUCTOR_C( defiTrack ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiTrack ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     DEF_COPY_FUNC( macroLength_ );
     DEF_MALLOC_FUNC( macro_, char, sizeof(char) * (strlen(prev.macro_) +1));
@@ -483,7 +485,7 @@ DEF_ASSIGN_OPERATOR_C( defiTrack ) {
     DEF_MALLOC_FUNC_FOR_2D_STR( layers_, numLayers_ );
     DEF_COPY_FUNC( firstTrackMask_ );
     DEF_COPY_FUNC( samemask_ );
-
+    return *this;
 }
 
 defiTrack::~defiTrack() {
@@ -657,12 +659,14 @@ DEF_COPY_CONSTRUCTOR_C( defiGcellGrid ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiGcellGrid ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     DEF_COPY_FUNC( macroLength_ );
     DEF_MALLOC_FUNC( macro_, char, sizeof(char) * (strlen(prev.macro_) +1));
     DEF_COPY_FUNC( x_ );
     DEF_COPY_FUNC( xNum_ );
     DEF_COPY_FUNC( xStep_ );
+    return *this;
 }
 
 defiGcellGrid::~defiGcellGrid() {

--- a/def/defiSite.cpp
+++ b/def/defiSite.cpp
@@ -209,6 +209,7 @@ DEF_COPY_CONSTRUCTOR_C( defiBox ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiBox ) {
+    CHECK_SELF_ASSIGN
     this->Init();
    
     DEF_COPY_FUNC( xl_ );
@@ -217,6 +218,7 @@ DEF_ASSIGN_OPERATOR_C( defiBox ) {
     DEF_COPY_FUNC( yh_ );
     
     DEF_MALLOC_FUNC_WITH_OPERATOR( points_, defiPoints, sizeof(defiPoints)*1 );
+    return *this;
 }
 
 defiBox::~defiBox() {

--- a/def/defiVia.cpp
+++ b/def/defiVia.cpp
@@ -112,7 +112,7 @@ DEF_COPY_CONSTRUCTOR_C( defiVia ) {
 }
 
 DEF_ASSIGN_OPERATOR_C( defiVia ) {
-    
+    CHECK_SELF_ASSIGN
     DEF_COPY_FUNC( defData );
     Init();
 
@@ -167,7 +167,7 @@ DEF_ASSIGN_OPERATOR_C( defiVia ) {
     DEF_COPY_FUNC( hasCutPattern_ );
     DEF_MALLOC_FUNC( rectMask_, int, sizeof(int) * numLayers_);
     DEF_MALLOC_FUNC( polyMask_, int, sizeof(int) * numLayers_);
-
+    return *this;
 }
 
 


### PR DESCRIPTION
The optimizations lead to segmentation faults. Since the parsing of
lef/def files is not a bottleneck for the project, removing them should
not impact runtime.