### PR TITLE
Fix 'LAYER' keyword when writting a track

### DIFF
--- a/def/defwWriter.cpp
+++ b/def/defwWriter.cpp
@@ -1088,19 +1088,22 @@ defwTracks(const char   *master,
         }
 
         if (sameMask) {
-            fprintf(defwFile, "TRACKS %s %d DO %d STEP %d MASK %d SAMEMASK LAYER",
+            fprintf(defwFile, "TRACKS %s %d DO %d STEP %d MASK %d SAMEMASK",
                     master, do_start, do_cnt, do_step, mask);
         } else {
-            fprintf(defwFile, "TRACKS %s %d DO %d STEP %d MASK %d LAYER",
+            fprintf(defwFile, "TRACKS %s %d DO %d STEP %d MASK %d",
                     master, do_start, do_cnt, do_step, mask);
         }
     } else {
-        fprintf(defwFile, "TRACKS %s %d DO %d STEP %d LAYER",
+        fprintf(defwFile, "TRACKS %s %d DO %d STEP %d",
                 master, do_start, do_cnt, do_step);
     }
 
-    for (i = 0; i < num_layers; i++) {
-        fprintf(defwFile, " %s", layers[i]);
+    if (num_layers > 0) {
+        fprintf(defwFile, " LAYER");
+        for (i = 0; i < num_layers; i++) {
+            fprintf(defwFile, " %s", layers[i]);
+        }
     }
     fprintf(defwFile, " ;\n");
     defwLines++;


### PR DESCRIPTION
According to the DEF syntax reference, the LAYER keyword is optional.

Up to this point we were writing the LAYER keyword even when the track had no
specified layers.

This lead to parsing errors when reading a DEF that for some tracks no LAYER wa
specified.